### PR TITLE
docs(readme): 修正 Colab 徽章連結

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 數據整合平台 v15 - 智慧更新版
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TaifexDataService/taifexd-data/blob/main/data_pipeline_v15/run_v16_stable.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TaifexDataService/taifexd-data/blob/main/data_pipeline_v15/run_stable.ipynb)
 
-**注意：** 我們建議使用 `data_pipeline_v15/run_v16_stable.ipynb` 做為新的穩定版本執行入口。
+**注意：** 我們建議使用 `data_pipeline_v15/run_stable.ipynb` 做為新的穩定版本執行入口。
 
 本專案是一個為處理台灣期貨交易所 (TAIFEX) 每日交易數據而設計的自動化數據整合平台。此版本內建智慧更新與參數化執行功能。
 
@@ -12,7 +12,7 @@
 
 ### 首次設定
 
-1.  點擊上方的 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TaifexDataService/taifexd-data/blob/main/data_pipeline_v15/run_v16_stable.ipynb) 徽章，開啟公版「樣板筆記本」。
+1.  點擊上方的 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/TaifexDataService/taifexd-data/blob/main/data_pipeline_v15/run_stable.ipynb) 徽章，開啟公版「樣板筆記本」。
 2.  在 Colab 選單中，點擊 **「檔案」(File)** -> **「在雲端硬碟中儲存複本」(Save a copy in Drive)**。
 3.  這會在您的 Google Drive 中建立一個專屬於您的「個人版筆記本」。**請關閉公版，並在您個人的版本上進行所有後續操作。**
 


### PR DESCRIPTION
- 我已將 README 檔案中所有指向舊版 Colab 筆記本 (`run_v16_stable.ipynb`) 的連結，全部更新為指向新的穩定版 `run_stable.ipynb`。
- 本次修正旨在解決因 URL 不正確導致「Open in Colab」徽章失效的問題。