### PR TITLE
fix(notebook): 修正 Poetry 安裝指令以解決依賴項遺失問題

### DIFF
--- a/run_stable.ipynb
+++ b/run_stable.ipynb
@@ -14,10 +14,7 @@
    "execution_count": null,
    "metadata": {
     "colab": {
-     "forms": {
-      " বিড়াল ": " และ ",
-      "test": "你好"
-     }
+     "forms": {}
     }
    },
    "outputs": [],
@@ -53,13 +50,11 @@
     "    print(f\"❌ Google Drive 掛載失敗: {e}\")\n",
     "    sys.exit(\"請檢查您的 Drive 授權設定。\")\n",
     "\n",
-    "# 步驟 2: 下載/更新專案程式碼 (*** 已修正此區塊 ***)\n",
+    "# 步驟 2: 下載/更新專案程式碼\n",
     "print(\"\\n⏳ 正在準備專案程式碼...\")\n",
     "REPO_PATH = '/content/taifexd-date'\n",
-    "# *** 使用正確的 GitHub Repo 網址 ***\n",
     "REPO_URL = 'https://github.com/hsp1234-web/taifexd-date.git'\n",
     "\n",
-    "# 判斷是更新 (pull) 還是全新下載 (clone)\n",
     "if os.path.exists(REPO_PATH):\n",
     "    print(f\"  - 找到現有目錄，執行 git pull 更新...\")\n",
     "    os.chdir(REPO_PATH)\n",
@@ -68,21 +63,18 @@
     "    print(f\"  - 執行 git clone 下載專案...\")\n",
     "    !git clone -q {REPO_URL} {REPO_PATH}\n",
     "\n",
-    "# *** 修正：直接進入專案的根目錄 ***\n",
-    "# 因為 main.py 和 pyproject.toml 都在根目錄\n",
     "os.chdir(REPO_PATH)\n",
     "print(f\"✅ 專案程式碼準備完成！目前工作目錄: {os.getcwd()}\\n\")\n",
     "\n",
     "# 步驟 3: 安裝與設定 Poetry (核心穩定性步驟)\n",
     "print(\"\\n⏳ 正在設定 Poetry 並安裝精確的依賴版本...\")\n",
-    "# 安裝 Poetry 並執行 install，它會讀取 pyproject.toml 來安裝依賴\n",
     "!pip install poetry -q\n",
-    "!poetry install --no-root --no-dev\n",
+    "# *** 已修正此處的指令，使用 --without dev 和 --sync ***\n",
+    "!poetry install --no-root --without dev --sync\n",
     "print(\"✅ 所有精確版本的 Python 套件均已安裝完成！\\n\")\n",
     "\n",
     "# 步驟 4: 建構並執行指令\n",
     "print(\"\\n🚀 即將啟動數據整合平台...\")\n",
-    "# poetry run 會自動使用此虛擬環境來執行 main.py\n",
     "command = (\n",
     "    f\"poetry run python main.py \"\n",
     "    f\"--project-folder-name='{project_folder}' \"\n",


### PR DESCRIPTION
- 我分析了 `ModuleNotFoundError: No module named 'duckdb'` 這個錯誤。
- 我發現 `poetry install` 指令使用了已棄用的 `--no-dev` 旗標，這導致了安裝失敗。
- 我將指令更新為現代且穩健的 `poetry install --no-root --without dev --sync`。
- 這項變更確保了所有專案依賴項都能被正確安裝到你的 Colab 環境中。