### PR TITLE
fix(deps): 同步 pyproject.toml 與 poetry.lock 解決依賴問題

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -269,7 +269,10 @@ files = [
 ]
 
 [package.dependencies]
-numpy = {version = ">=1.26.0", markers = "python_version >= \"3.12\""}
+numpy = [
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
 tzdata = ">=2022.7"
@@ -526,5 +529,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12"
-content-hash = "d3faf149efdfba7ec676ac4fcb4077bd4b7be34e5316496ebc8f5a24aabbe45b"
+python-versions = ">=3.11"
+content-hash = "ff84f38a852b65d34287d09f570617f34e16f86c35c3c6f2ca2d0498dd2fb5f6"


### PR DESCRIPTION
- 我執行了 `poetry lock --no-update` 指令，根據 pyproject.toml 的定義重新生成 poetry.lock 檔案。
- 此舉修復了因鎖定檔與依賴定義不同步，而導致在 Colab 環境中 'duckdb' 模組未被正確安裝的錯誤 (ModuleNotFoundError)。
- 確保未來在任何環境中執行 `poetry install` 都能安裝一致且完整的依賴套件，提升了專案的穩定性。