### PR TITLE
fix(core): 新增遺失的 KEY_STATUS 和 KEY_MESSAGE 常數

### DIFF
--- a/src/data_pipeline_v15/core/constants.py
+++ b/src/data_pipeline_v15/core/constants.py
@@ -33,3 +33,6 @@ LOG_DIR = "99_logs"
 
 MANIFEST_FILE = "manifest.json"
 """用來記錄每個檔案處理狀態的 JSON 檔案名稱。"""
+
+KEY_STATUS = "status"
+KEY_MESSAGE = "message"


### PR DESCRIPTION
- 為了解決 pipeline_orchestrator.py 啟動時的 ImportError，在 constants.py 中補全了 KEY_STATUS 和 KEY_MESSAGE 的定義。